### PR TITLE
adding function to allow arbitrary colors in ramp call

### DIFF
--- a/src/fn/fn-colors.js
+++ b/src/fn/fn-colors.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('es6-promise').polyfill();
+
+var debug = require('../helper/debug')('fn-factory');
+
+module.exports = function () {
+  return function fn$colors () {
+    var args = arguments
+    return new Promise(function (resolve) {
+      var colors = Object.keys(args).map(function(k){return args[k]})
+      resolve(colors);
+    });
+  }
+};
+
+module.exports.fnName = 'colors';

--- a/src/fn/fn-colors.js
+++ b/src/fn/fn-colors.js
@@ -6,12 +6,13 @@ var debug = require('../helper/debug')('fn-factory');
 
 module.exports = function () {
   return function fn$colors () {
-    var args = arguments
+    var args = arguments;
+    debug('fn$colors(%j)', arguments);
     return new Promise(function (resolve) {
-      var colors = Object.keys(args).map(function(k){return args[k]})
+      var colors = Object.keys(args).map(function (k) { return args[k]; });
       resolve(colors);
     });
-  }
+  };
 };
 
 module.exports.fnName = 'colors';

--- a/src/fn/fn-factory.js
+++ b/src/fn/fn-factory.js
@@ -3,7 +3,8 @@
 var fns = [
   require('./fn-ramp'),
   require('./fn-colorbrew'),
-  require('./fn-buckets')
+  require('./fn-buckets'),
+  require('./fn-colors')
 ];
 var fnIdentity = require('./fn-identity');
 

--- a/test/unit/fn-colors.test.js
+++ b/test/unit/fn-colors.test.js
@@ -6,7 +6,7 @@ var fnColors = require('../../src/fn/fn-colors');
 describe('fn-colors', function () {
   var fn = fnColors();
   it('should return what its given', function (done) {
-    fn('red','green','blue').then(function (result) {
+    fn('red', 'green', 'blue').then(function (result) {
       assert.deepEqual(result, [ 'red', 'green', 'blue' ]);
       done();
     });

--- a/test/unit/fn-colors.test.js
+++ b/test/unit/fn-colors.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var assert = require('assert');
+var fnColors = require('../../src/fn/fn-colors');
+
+describe('fn-colors', function () {
+  var fn = fnColors();
+  it('should return what its given', function (done) {
+    fn('red','green','blue').then(function (result) {
+      assert.deepEqual(result, [ 'red', 'green', 'blue' ]);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Adding a simple function to allow arbitrary colors to be used with the ramp function. This is important if you want to use a custom color ramp but still use the data defined binning. 

usage : 
```css
    marker-fill: ramp([pop_max], colors(#ff0000, #00ff00, #0000ff, #ff00ff), jenks);
```

@makella @rochoa